### PR TITLE
Handle backslashes in JSON data

### DIFF
--- a/app/ext/ApexExtensions.java
+++ b/app/ext/ApexExtensions.java
@@ -5,6 +5,6 @@ import play.templates.JavaExtensions;
 public class ApexExtensions extends JavaExtensions {
 
 	public static String escapeApex(String src) {
-		return src.replace("\"", "\\\"").replace("\r\n", "\\n").replace("\r", "\\n").replace("\n", "\\n");
+		return src.replace("\\", "\\\\").replace("\"", "\\\"").replace("\r\n", "\\n").replace("\r", "\\n").replace("\n", "\\n");
 	}
 }


### PR DESCRIPTION
I was seeing an error when running the test method with input data containing \r\n (you see this in Facebook user data, for example). Escaping backslashes present in the JSON input handles this nicely.
