### PR TITLE
Escape single quotes

### DIFF
--- a/app/ext/ApexExtensions.java
+++ b/app/ext/ApexExtensions.java
@@ -5,6 +5,6 @@ import play.templates.JavaExtensions;
 public class ApexExtensions extends JavaExtensions {
 
 	public static String escapeApex(String src) {
-		return src.replace("\\", "\\\\").replace("\"", "\\\"").replace("\r\n", "\\n").replace("\r", "\\n").replace("\n", "\\n");
+		return src.replace("\\", "\\\\").replace("\'", "\\\'").replace("\"", "\\\"").replace("\r\n", "\\n").replace("\r", "\\n").replace("\n", "\\n");
 	}
 }


### PR DESCRIPTION
Single quotes in JSON input were not being escaped - caused error when saving Apex class.

Test data

{
  "key": "I'm a value"
}
