### PR TITLE
Handle nulls when parsing JSON

### DIFF
--- a/app/views/Application/makeApexWithParse.txt
+++ b/app/views/Application/makeApexWithParse.txt
@@ -38,36 +38,37 @@ public class ${className} {
 #{get 'indent' /}		while (parser.nextToken() != JSONToken.END_OBJECT) {
 #{get 'indent' /}			if (parser.getCurrentToken() == JSONToken.FIELD_NAME) {
 #{get 'indent' /}				String text = parser.getText();
-#{get 'indent' /}				parser.nextToken();
-#{get 'indent' /}				#{list items:cls.members.entrySet(), as:'m'}
+#{get 'indent' /}				if (parser.nextToken() != JSONToken.VALUE_NULL) {
+#{get 'indent' /}					#{list items:cls.members.entrySet(), as:'m'}
 if (text == '${m.key}') {
 #{if m.value.toString() == 'String'}
-#{get 'indent' /}					${m.key} = parser.getText();
+#{get 'indent' /}						${m.key} = parser.getText();
 #{/if}
 #{elseif m.value.toString() == 'Integer'}
-#{get 'indent' /}					${m.key} = parser.getIntegerValue();
+#{get 'indent' /}						${m.key} = parser.getIntegerValue();
 #{/elseif}
 #{elseif m.value.toString() == 'Double'}
-#{get 'indent' /}					${m.key} = parser.getDoubleValue();
+#{get 'indent' /}						${m.key} = parser.getDoubleValue();
 #{/elseif}
 #{elseif m.value.toString() == 'Boolean'}
-#{get 'indent' /}					${m.key} = parser.getBooleanValue();
+#{get 'indent' /}						${m.key} = parser.getBooleanValue();
 #{/elseif}
 #{elseif m.value.toString() == 'Long'}
-#{get 'indent' /}					${m.key} = parser.getLongValue();
+#{get 'indent' /}						${m.key} = parser.getLongValue();
 #{/elseif}
 #{elseif m.value.toString().startsWith('List<')}
-#{get 'indent' /}					${m.key} = new ${m.value}();
-#{get 'indent' /}					while (parser.nextToken() != JSONToken.END_ARRAY) {
-#{get 'indent' /}						${m.key}.add(new ${m.value.itemType()}(parser));
-#{get 'indent' /}					}
+#{get 'indent' /}						${m.key} = new ${m.value}();
+#{get 'indent' /}						while (parser.nextToken() != JSONToken.END_ARRAY) {
+#{get 'indent' /}							${m.key}.add(new ${m.value.itemType()}(parser));
+#{get 'indent' /}						}
 #{/elseif}
 #{else}
-#{get 'indent' /}					${m.key} = new ${m.value}(parser);
+#{get 'indent' /}						${m.key} = new ${m.value}(parser);
 #{/else}
-#{get 'indent' /}				} else #{/list}{
-#{get 'indent' /}					System.debug(LoggingLevel.WARN, '${cls} consuming unrecognized property: '+text);
-#{get 'indent' /}					consumeObject(parser);
+#{get 'indent' /}					} else #{/list}{
+#{get 'indent' /}						System.debug(LoggingLevel.WARN, '${cls} consuming unrecognized property: '+text);
+#{get 'indent' /}						consumeObject(parser);
+#{get 'indent' /}					}
 #{get 'indent' /}				}
 #{get 'indent' /}			}
 #{get 'indent' /}		}


### PR DESCRIPTION
Runtime parser currently breaks when it encounters a null value in JSON input. For example:

{
    "key1": null,
    "key2": "value2"
}

This change allows the parser to consume the null, leaving the corresponding field unchanged, and move on to the next field name.
